### PR TITLE
Try to find assets relative to binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,4 +134,4 @@ test-hl: export/hl
 
 .PHONY: test-native
 test-native: export/native
-	export/native/lazycat
+	cd export/native; ./lazycat

--- a/lazycat/Main.hx
+++ b/lazycat/Main.hx
@@ -127,6 +127,11 @@ class Main extends hxd.App {
 	}
 
 	static function main() {
+		#if sys
+		var currentPath:String = Sys.programPath();
+		currentPath = haxe.io.Path.directory(currentPath);
+		Sys.setCwd(currentPath);
+		#end
 		new Main(new Assets());
 	}
 }


### PR DESCRIPTION
Will not work if lazycat is run from a script, but it's better than
nothing.

Fixes #59